### PR TITLE
chore: remove declarationMap and restrict published files

### DIFF
--- a/packages/esroute-lit/package.json
+++ b/packages/esroute-lit/package.json
@@ -11,6 +11,7 @@
       "default": "./dist/index.js"
     }
   },
+  "files": ["dist", "LICENSE", "README.md"],
   "sideEffects": false,
   "license": "MIT",
   "author": "Sven Rogge <mail@sven-rogge.com>",

--- a/packages/esroute/package.json
+++ b/packages/esroute/package.json
@@ -11,6 +11,7 @@
       "default": "./dist/index.js"
     }
   },
+  "files": ["dist", "LICENSE", "README.md"],
   "sideEffects": false,
   "license": "MIT",
   "author": "Sven Rogge <mail@sven-rogge.com>",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
     "moduleDetection": "force",
     "moduleResolution": "node16",
     "declaration": true,
-    "declarationMap": true,
     "sourceMap": true,
     "strict": true,
     "skipLibCheck": true


### PR DESCRIPTION
## Summary
- Remove `declarationMap: true` from root `tsconfig.json` — declaration maps are not needed for consumers
- Add `files` field to both `esroute` and `@esroute/lit` packages to only publish `dist/`, `LICENSE`, and `README.md`, excluding `tsconfig.check.json`, `tsconfig.tsbuildinfo`, and source files

## Test plan
- [ ] Run `npm run build` and confirm no `.d.ts.map` files in `dist/`
- [ ] Run `npm pack --dry-run` in each package and confirm only `dist/`, `LICENSE`, and `README.md` are included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized published packages to include only essential files (distribution, license, and documentation), reducing download size and improving installation efficiency
  * Refined TypeScript build configuration for streamlined compilation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->