### PR TITLE
chore: bump versions to 0.12.4

### DIFF
--- a/packages/esroute-lit/package.json
+++ b/packages/esroute-lit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esroute/lit",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "A small efficient client-side routing library for lit, written in TypeScript.",
   "type": "module",
   "types": "dist/index.d.ts",
@@ -11,6 +11,7 @@
       "default": "./dist/index.js"
     }
   },
+  "files": ["dist", "LICENSE", "README.md"],
   "sideEffects": false,
   "license": "MIT",
   "author": "Sven Rogge <mail@sven-rogge.com>",

--- a/packages/esroute/package.json
+++ b/packages/esroute/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esroute",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "A small efficient framework-agnostic client-side routing library, written in TypeScript.",
   "type": "module",
   "types": "dist/index.d.ts",
@@ -11,6 +11,7 @@
       "default": "./dist/index.js"
     }
   },
+  "files": ["dist", "LICENSE", "README.md"],
   "sideEffects": false,
   "license": "MIT",
   "author": "Sven Rogge <mail@sven-rogge.com>",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
     "moduleDetection": "force",
     "moduleResolution": "node16",
     "declaration": true,
-    "declarationMap": true,
     "sourceMap": true,
     "strict": true,
     "skipLibCheck": true


### PR DESCRIPTION
## Summary
- Bump `esroute` and `@esroute/lit` to `0.12.4`

## Test plan
- [ ] `npm publish` in both packages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bump for `@esroute/lit` and `esroute` packages (0.12.3 → 0.12.4)
  * Optimized package distribution by constraining published files to essential contents

<!-- end of auto-generated comment: release notes by coderabbit.ai -->